### PR TITLE
Tweak to allow the latest release of ramsey/uuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
-        "ramsey/uuid": "~2.5",
+        "php": ">=5.4",
+        "ramsey/uuid": "~3.0",
         "mathiasverraes/money": "~1.2",
         "marc-mabe/php-enum": "~1.0",
         "zendframework/zend-validator": "~2.2",

--- a/src/Identity/UUID.php
+++ b/src/Identity/UUID.php
@@ -6,7 +6,7 @@ use ValueObjects\Exception\InvalidNativeArgumentException;
 use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Util\Util;
 use ValueObjects\ValueObjectInterface;
-use Rhumsaa\Uuid\Uuid as BaseUuid;
+use Ramsey\Uuid\Uuid as BaseUuid;
 
 class UUID extends StringLiteral
 {


### PR DESCRIPTION
Updated composer.json to ```~3.0``` for ramsey/uuid and changed the namespace of the Uuid base class from Rhumsaa to Ramsey in ```Identity\UUID```