### PR TITLE
Fix: Type should be StringLiteral

### DIFF
--- a/src/DateTime/TimeZone.php
+++ b/src/DateTime/TimeZone.php
@@ -91,7 +91,7 @@ class TimeZone implements ValueObjectInterface
     /**
      * Returns timezone name
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getName()
     {

--- a/src/Geography/Address.php
+++ b/src/Geography/Address.php
@@ -10,7 +10,7 @@ class Address implements ValueObjectInterface
 {
     /**
      * Name of the addressee (natural person or company)
-     * @var String
+     * @var StringLiteral
      */
     protected $name;
 
@@ -19,25 +19,25 @@ class Address implements ValueObjectInterface
 
     /**
      * District/City area
-     * @var String
+     * @var StringLiteral
      */
     protected $district;
 
     /**
      * City/Town/Village
-     * @var String
+     * @var StringLiteral
      */
     protected $city;
 
     /**
      * Region/County/State
-     * @var String
+     * @var StringLiteral
      */
     protected $region;
 
     /**
      * Postal code/P.O. Box/ZIP code
-     * @var String
+     * @var StringLiteral
      */
     protected $postalCode;
 
@@ -80,12 +80,12 @@ class Address implements ValueObjectInterface
     /**
      * Returns a new Address object
      *
-     * @param String  $name
-     * @param Street  $street
-     * @param String  $district
-     * @param String  $city
-     * @param String  $region
-     * @param String  $postalCode
+     * @param StringLiteral $name
+     * @param Street        $street
+     * @param StringLiteral $district
+     * @param StringLiteral $city
+     * @param StringLiteral $region
+     * @param StringLiteral $postalCode
      * @param Country $country
      */
     public function __construct(StringLiteral $name, Street $street, StringLiteral $district, StringLiteral $city, StringLiteral $region, StringLiteral $postalCode, Country $country)
@@ -124,7 +124,7 @@ class Address implements ValueObjectInterface
     /**
      * Returns addressee name
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getName()
     {
@@ -144,7 +144,7 @@ class Address implements ValueObjectInterface
     /**
      * Returns district
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getDistrict()
     {
@@ -154,7 +154,7 @@ class Address implements ValueObjectInterface
     /**
      * Returns city
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getCity()
     {
@@ -164,7 +164,7 @@ class Address implements ValueObjectInterface
     /**
      * Returns region
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getRegion()
     {
@@ -174,7 +174,7 @@ class Address implements ValueObjectInterface
     /**
      * Returns postal code
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getPostalCode()
     {

--- a/src/Geography/Coordinate.php
+++ b/src/Geography/Coordinate.php
@@ -115,7 +115,7 @@ class Coordinate implements ValueObjectInterface
     /**
      * Returns a degrees/minutes/seconds representation of the coordinate
      *
-     * @return String
+     * @return StringLiteral
      */
     public function toDegreesMinutesSeconds()
     {
@@ -129,7 +129,7 @@ class Coordinate implements ValueObjectInterface
     /**
      * Returns a decimal minutes representation of the coordinate
      *
-     * @return String
+     * @return StringLiteral
      */
     public function toDecimalMinutes()
     {
@@ -143,7 +143,7 @@ class Coordinate implements ValueObjectInterface
     /**
      * Returns a Universal Transverse Mercator projection representation of the coordinate in meters
      *
-     * @return String
+     * @return StringLiteral
      */
     public function toUniversalTransverseMercator()
     {

--- a/src/Geography/Country.php
+++ b/src/Geography/Country.php
@@ -63,7 +63,7 @@ class Country implements ValueObjectInterface
     /**
      * Returns country name
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getName()
     {

--- a/src/Geography/CountryCodeName.php
+++ b/src/Geography/CountryCodeName.php
@@ -257,7 +257,7 @@ class CountryCodeName
      * Returns country name
      *
      * @param  CountryCode $code
-     * @return String
+     * @return StringLiteral
      */
     public static function getName(CountryCode $code)
     {

--- a/src/Geography/Street.php
+++ b/src/Geography/Street.php
@@ -14,11 +14,11 @@ class Street implements ValueObjectInterface
     /** @var StringLiteral */
     protected $number;
 
-    /** @var String Building, floor and unit */
+    /** @var StringLiteral Building, floor and unit */
     protected $elements;
 
     /**
-     * @var String __toString() format
+     * @var StringLiteral __toString() format
      * Use properties corresponding placeholders: %name%, %number%, %elements%
      */
     protected $format;
@@ -56,8 +56,8 @@ class Street implements ValueObjectInterface
     /**
      * Returns a new Street object
      *
-     * @param String $name
-     * @param String $number
+     * @param StringLiteral $name
+     * @param StringLiteral $number
      */
     public function __construct(StringLiteral $name, StringLiteral $number, StringLiteral $elements = null, StringLiteral $format = null)
     {
@@ -95,7 +95,7 @@ class Street implements ValueObjectInterface
     /**
      * Returns street name
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getName()
     {
@@ -105,7 +105,7 @@ class Street implements ValueObjectInterface
     /**
      * Returns street number
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getNumber()
     {
@@ -114,7 +114,7 @@ class Street implements ValueObjectInterface
 
     /**
      * Returns street elements
-     * @return String
+     * @return StringLiteral
      */
     public function getElements()
     {

--- a/src/Person/Name.php
+++ b/src/Person/Name.php
@@ -51,9 +51,9 @@ class Name implements ValueObjectInterface
     /**
      * Returns a Name object
      *
-     * @param String $first_name
-     * @param String $middle_name
-     * @param String $last_name
+     * @param StringLiteral $first_name
+     * @param StringLiteral $middle_name
+     * @param StringLiteral $last_name
      */
     public function __construct(StringLiteral $first_name, StringLiteral $middle_name, StringLiteral $last_name)
     {
@@ -65,7 +65,7 @@ class Name implements ValueObjectInterface
     /**
      * Returns the first name
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getFirstName()
     {
@@ -75,7 +75,7 @@ class Name implements ValueObjectInterface
     /**
      * Returns the middle name
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getMiddleName()
     {
@@ -85,7 +85,7 @@ class Name implements ValueObjectInterface
     /**
      * Returns the last name
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getLastName()
     {
@@ -95,7 +95,7 @@ class Name implements ValueObjectInterface
     /**
      * Returns the full name
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getFullName()
     {

--- a/src/Web/EmailAddress.php
+++ b/src/Web/EmailAddress.php
@@ -26,7 +26,7 @@ class EmailAddress extends StringLiteral
     /**
      * Returns the local part of the email address
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getLocalPart()
     {

--- a/src/Web/Url.php
+++ b/src/Web/Url.php
@@ -65,8 +65,8 @@ class Url implements ValueObjectInterface
      * Returns a new Url object
      *
      * @param SchemeName          $scheme
-     * @param String              $user
-     * @param String              $password
+     * @param StringLiteral       $user
+     * @param StringLiteral       $password
      * @param Domain              $domain
      * @param Path                $path
      * @param PortNumberInterface $port
@@ -131,7 +131,7 @@ class Url implements ValueObjectInterface
     /**
      * Returns the password part of the Url
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getPassword()
     {
@@ -181,7 +181,7 @@ class Url implements ValueObjectInterface
     /**
      * Returns the user part of the Url
      *
-     * @return String
+     * @return StringLiteral
      */
     public function getUser()
     {


### PR DESCRIPTION
This PR

* [x] updates docblocks following the rename of `String` to `StringLiteral`

Follows https://github.com/nicolopignatelli/valueobjects/pull/37.