### PR TITLE
Fix: Namespace segment should be Person

### DIFF
--- a/tests/Person/NameTest.php
+++ b/tests/Person/NameTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ValueObjects\Tests\String;
+namespace ValueObjects\Tests\Person;
 
 use ValueObjects\Person\Name;
 use ValueObjects\Tests\TestCase;


### PR DESCRIPTION
This PR

* [x] fixes a namespace segment in a test

Somewhat related to #54.