### PR TITLE
Upgrade Geotools package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "mathiasverraes/money": "~1.2",
         "marc-mabe/php-enum": "~1.0",
         "zendframework/zend-validator": "~2.2",
-        "league/geotools": "~0.3.1"
+        "league/geotools": "~0.7"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Upgrade Geotools package to allow usage of last major release of [Geocoder](https://github.com/geocoder-php/Geocoder).