### PR TITLE
fix Url port phpdoc declaration

### DIFF
--- a/src/Web/Url.php
+++ b/src/Web/Url.php
@@ -23,7 +23,7 @@ class Url implements ValueObjectInterface
     /** @var Path */
     protected $path;
 
-    /** @var PortNumber */
+    /** @var PortNumberInterface */
     protected $port;
 
     /** @var QueryString */


### PR DESCRIPTION
The parameter `$port` must be declared of type `PortNumberInterface`, since it could be also an instance of `NullPortNumber`